### PR TITLE
build: remove use lucide-react/dynamicIconImports to send only used i…

### DIFF
--- a/src/layout/body-app/header/header-actions/index.tsx
+++ b/src/layout/body-app/header/header-actions/index.tsx
@@ -1,3 +1,4 @@
+import { LogOut } from 'lucide-react';
 import { useState } from 'react';
 
 import { useAuth } from '@core/store/context/AuthContext';
@@ -26,7 +27,7 @@ const HeaderActions = () => {
       <ThemeSwitcher />
 
       <Button
-        icon="log-out"
+        icon={LogOut}
         variant="ghost"
         size="icon"
         title="Sair"
@@ -36,7 +37,7 @@ const HeaderActions = () => {
       <Modal
         open={openModal}
         title="Sair do sistema"
-        icon="log-out"
+        icon={LogOut}
         confirmText="Sim"
         onConfirmClick={handleLogout}
         cancelText="Não"

--- a/src/modules/client-register/index.tsx
+++ b/src/modules/client-register/index.tsx
@@ -1,4 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
+import { CircleUserRound } from 'lucide-react';
 import { useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import z from 'zod';
@@ -65,7 +66,7 @@ export default function ClientRegister() {
           form={form}
           onValid={handleValid}
           title="Cadastro de Cliente"
-          icon="circle-user-round"
+          icon={CircleUserRound}
           useDefaultGrid={false}
           border
         >

--- a/src/modules/client/budget-search/index.tsx
+++ b/src/modules/client/budget-search/index.tsx
@@ -1,3 +1,4 @@
+import { Receipt } from 'lucide-react';
 import { useSearchParams } from 'react-router-dom';
 
 import { useLicenseSearchBudgets } from '@core/service/budget';
@@ -30,7 +31,7 @@ export default function ClientBudgetSearch() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle icon="receipt">Orçamentos</CardTitle>
+        <CardTitle icon={Receipt}>Orçamentos</CardTitle>
       </CardHeader>
 
       <CardContent className="space-y-4">

--- a/src/modules/client/budget-view/action-buttons/approve-button/index.tsx
+++ b/src/modules/client/budget-view/action-buttons/approve-button/index.tsx
@@ -1,3 +1,4 @@
+import { CheckCheck, ThumbsUp } from 'lucide-react';
 import { useState } from 'react';
 
 import { useApproveBudget } from '@core/service/budget';
@@ -36,14 +37,14 @@ export default function ApproveButton() {
 
   return (
     <>
-      <Button icon="thumbs-up" onClick={() => setOpenConfirmModal(true)}>
+      <Button icon={ThumbsUp} onClick={() => setOpenConfirmModal(true)}>
         Aprovar orçamento
       </Button>
 
       <Modal
         open={openConfirmModal}
         title="Confirma a aprovação do orçamento?"
-        icon="check-check"
+        icon={CheckCheck}
         onConfirmClick={handleApproveBudget}
         onCancelClick={() => setOpenConfirmModal(false)}
       />

--- a/src/modules/client/budget-view/action-buttons/receive-car/index.tsx
+++ b/src/modules/client/budget-view/action-buttons/receive-car/index.tsx
@@ -1,3 +1,4 @@
+import { CheckCheck } from 'lucide-react';
 import { useState } from 'react';
 
 import { useFinishBudget } from '@core/service/budget';
@@ -28,7 +29,7 @@ export default function ReceiveButton() {
 
   return (
     <>
-      <Button icon="check-check" onClick={handleFinishBudget}>
+      <Button icon={CheckCheck} onClick={handleFinishBudget}>
         Veículo recebido
       </Button>
 

--- a/src/modules/client/budget-view/action-buttons/reject-button/index.tsx
+++ b/src/modules/client/budget-view/action-buttons/reject-button/index.tsx
@@ -1,3 +1,4 @@
+import { ThumbsDown } from 'lucide-react';
 import { useState } from 'react';
 
 import { useRemakeBudget } from '@core/service/budget';
@@ -36,14 +37,14 @@ export default function RejectButton() {
 
   return (
     <>
-      <Button icon="thumbs-down" variant="destructive" onClick={() => setOpenConfirmModal(true)}>
+      <Button icon={ThumbsDown} variant="destructive" onClick={() => setOpenConfirmModal(true)}>
         Rejeitar orçamento
       </Button>
 
       <Modal
         open={openConfirmModal}
         title="Confirma a rejeição do orçamento?"
-        icon="thumbs-down"
+        icon={ThumbsDown}
         confirmVariant="destructive"
         onConfirmClick={handleRejectBudget}
         onCancelClick={() => setOpenConfirmModal(false)}

--- a/src/modules/client/budget-view/index.tsx
+++ b/src/modules/client/budget-view/index.tsx
@@ -1,3 +1,5 @@
+import { Receipt } from 'lucide-react';
+
 import { useGetBudget, useObservationUpdate } from '@core/service/budget';
 import { BudgetViewProvider } from '@core/store/context/BudgetViewContext/provider';
 import BudgetViewActionButtons from '@modules/client/budget-view/action-buttons';
@@ -31,7 +33,7 @@ function ClientBudgetViewContent() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle icon="receipt">Orçamento {os}</CardTitle>
+        <CardTitle icon={Receipt}>Orçamento {os}</CardTitle>
       </CardHeader>
 
       <CardContent>

--- a/src/modules/client/car-view/index.tsx
+++ b/src/modules/client/car-view/index.tsx
@@ -1,3 +1,4 @@
+import { Car } from 'lucide-react';
 import { useParams } from 'react-router-dom';
 
 import { useGetCar } from '@core/service/car';
@@ -21,7 +22,7 @@ export default function ClientCarView() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle icon="car">Veículo {car?.license}</CardTitle>
+        <CardTitle icon={Car}>Veículo {car?.license}</CardTitle>
         <CardDescription>{!!car && carName(car)}</CardDescription>
       </CardHeader>
 

--- a/src/modules/client/index.tsx
+++ b/src/modules/client/index.tsx
@@ -1,3 +1,5 @@
+import { Car, FileSearch2, FolderInput, Receipt, Warehouse } from 'lucide-react';
+
 import BodyApp from '@layout/body-app';
 
 export default function ClientContent() {
@@ -7,27 +9,27 @@ export default function ClientContent() {
         {
           title: 'Meus veículos',
           route: '/cliente',
-          icon: 'warehouse',
+          icon: Warehouse,
         },
         {
           title: 'Cadastrar veículo',
           route: '/cliente/cadastrar-veiculo',
-          icon: 'car',
+          icon: Car,
         },
         {
           title: 'Orçamentos',
           route: '/cliente/orcamentos',
-          icon: 'receipt',
+          icon: Receipt,
         },
         {
           title: 'Transferir veículo',
           route: '/cliente/transferir',
-          icon: 'folder-input',
+          icon: FolderInput,
         },
         {
           title: 'Consultar Placa',
           route: '/cliente/consulta-placa',
-          icon: 'file-search-2',
+          icon: FileSearch2,
         },
       ]}
     />

--- a/src/modules/client/my-cars/index.tsx
+++ b/src/modules/client/my-cars/index.tsx
@@ -1,3 +1,5 @@
+import { Warehouse } from 'lucide-react';
+
 import { useClientCars } from '@core/service/client';
 import { MY_CARS_CARD_TEST_ID } from '@modules/client/my-cars/consts';
 import { ListCars } from '@modules/client/my-cars/list-cars';
@@ -11,7 +13,7 @@ export default function ClientMyCars() {
   return (
     <Card data-testid={MY_CARS_CARD_TEST_ID}>
       <CardHeader>
-        <CardTitle icon="warehouse">Meus Veículos</CardTitle>
+        <CardTitle icon={Warehouse}>Meus Veículos</CardTitle>
       </CardHeader>
 
       <CardContent>

--- a/src/modules/client/my-cars/not-found-cars/index.tsx
+++ b/src/modules/client/my-cars/not-found-cars/index.tsx
@@ -1,3 +1,5 @@
+import { Car } from 'lucide-react';
+
 import { Alert, AlertDescription, AlertTitle } from '@shared/design-system/ui/alert';
 import LinkButton from '@shared/design-system/ui/link-button';
 
@@ -6,7 +8,7 @@ export function NotFoundCars() {
     <Alert>
       <AlertTitle>Você não possui nenhum veículo cadastrado.</AlertTitle>
       <AlertDescription>
-        <LinkButton icon="car" to="/cliente/cadastrar-veiculo">
+        <LinkButton icon={Car} to="/cliente/cadastrar-veiculo">
           Cadastrar seu veículo
         </LinkButton>
       </AlertDescription>

--- a/src/modules/client/transfer-car/index.tsx
+++ b/src/modules/client/transfer-car/index.tsx
@@ -1,4 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
+import { Car, FolderCheck, FolderInput } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import z from 'zod';
@@ -91,7 +92,7 @@ export default function ClientTransferCar() {
     return (
       <Card>
         <CardHeader>
-          <CardTitle icon="folder-input">Transferência de veículo</CardTitle>
+          <CardTitle icon={FolderInput}>Transferência de veículo</CardTitle>
         </CardHeader>
 
         <CardContent>
@@ -99,7 +100,7 @@ export default function ClientTransferCar() {
             <AlertTitle>Nehum veículo encontrado para para transferir.</AlertTitle>
 
             <AlertDescription>
-              <LinkButton icon="car" to="/cliente/cadastrar-veiculo">
+              <LinkButton icon={Car} to="/cliente/cadastrar-veiculo">
                 Cadastrar seu veículo
               </LinkButton>
             </AlertDescription>
@@ -114,7 +115,7 @@ export default function ClientTransferCar() {
       <Form
         form={form}
         title="Transferência de veículo"
-        icon="folder-input"
+        icon={FolderInput}
         confirmButtonText="Continuar"
         onValid={handleValid}
         useDefaultGrid={false}
@@ -130,7 +131,7 @@ export default function ClientTransferCar() {
       <Modal
         open={openModal}
         title="Confirmação dos dados da Transferência de Veículo"
-        icon="folder-check"
+        icon={FolderCheck}
         confirmText="Transferir"
         onConfirmClick={handleTrasnferCar}
         onCancelClick={() => setOpenModal(false)}

--- a/src/modules/garage-register/index.tsx
+++ b/src/modules/garage-register/index.tsx
@@ -1,4 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
+import { Warehouse } from 'lucide-react';
 import { useState } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { z } from 'zod';
@@ -68,7 +69,7 @@ export default function GarageRegister() {
           form={form}
           onValid={handleValid}
           title="Cadastro de Mecânica"
-          icon="warehouse"
+          icon={Warehouse}
           useDefaultGrid={false}
           border
         >

--- a/src/modules/garage/budget-add/car-fields/index.tsx
+++ b/src/modules/garage/budget-add/car-fields/index.tsx
@@ -1,3 +1,4 @@
+import { Car } from 'lucide-react';
 import { useFormContext } from 'react-hook-form';
 import { useDebouncedCallback } from 'use-debounce';
 
@@ -37,7 +38,7 @@ export default function CarFields() {
 
   return (
     <div className="col-span-full space-y-2">
-      <CardTitle icon="car" size="lg">
+      <CardTitle icon={Car} size="lg">
         Dados do veículo
       </CardTitle>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">

--- a/src/modules/garage/budget-add/client-fields/index.tsx
+++ b/src/modules/garage/budget-add/client-fields/index.tsx
@@ -1,3 +1,4 @@
+import { ArrowRight, User } from 'lucide-react';
 import { ChangeEvent } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useDebouncedCallback } from 'use-debounce';
@@ -48,7 +49,7 @@ export function ClientData() {
 
   return (
     <>
-      <CardTitle className="col-span-full" icon="user" size="lg">
+      <CardTitle className="col-span-full" icon={User} size="lg">
         Dados do Cliente
       </CardTitle>
 
@@ -99,7 +100,7 @@ export function ClientData() {
           <div className="col-span-full justify-self-end">
             <Button
               data-testid={SELECT_CAR_BUDGET_ADD_BUTTON_TESTID}
-              secondIcon="arrow-right"
+              secondIcon={ArrowRight}
               onClick={handleClick}
             >
               Selecionar Veículo

--- a/src/modules/garage/budget-add/index.tsx
+++ b/src/modules/garage/budget-add/index.tsx
@@ -1,3 +1,4 @@
+import { CircleDollarSign } from 'lucide-react';
 import { useState } from 'react';
 import { SubmitHandler, useFormContext } from 'react-hook-form';
 
@@ -83,7 +84,7 @@ function BudgetAddContent() {
         form={form}
         onValid={handleValid}
         title="Adicionar Orçamento"
-        icon="circle-dollar-sign"
+        icon={CircleDollarSign}
         confirmButtonText="Cadastrar Orçamento"
         showFooter={allowSelectCar}
       >

--- a/src/modules/garage/budget-view/actions/back-to-budget/index.tsx
+++ b/src/modules/garage/budget-view/actions/back-to-budget/index.tsx
@@ -1,3 +1,4 @@
+import { CornerUpLeft } from 'lucide-react';
 import { useState } from 'react';
 
 import { useRemakeBudget } from '@core/service/budget';
@@ -28,7 +29,7 @@ export default function BackToBudget() {
 
   return (
     <>
-      <Button icon="corner-up-left" variant="outline" onClick={handleSendForApproval}>
+      <Button icon={CornerUpLeft} variant="outline" onClick={handleSendForApproval}>
         Voltar para realizar orçamento
       </Button>
 

--- a/src/modules/garage/budget-view/actions/completed-budget/index.tsx
+++ b/src/modules/garage/budget-view/actions/completed-budget/index.tsx
@@ -1,3 +1,4 @@
+import { Receipt } from 'lucide-react';
 import { useState } from 'react';
 
 import { useCompletedBudget } from '@core/service/budget';
@@ -28,7 +29,7 @@ export default function CompletedService() {
 
   return (
     <>
-      <Button icon="receipt" color="primary" onClick={handleSendForApproval}>
+      <Button icon={Receipt} color="primary" onClick={handleSendForApproval}>
         Finalizar serviço
       </Button>
 

--- a/src/modules/garage/budget-view/actions/index.tsx
+++ b/src/modules/garage/budget-view/actions/index.tsx
@@ -1,3 +1,5 @@
+import { CircleOff } from 'lucide-react';
+
 import useBudgetViewContext from '@core/store/context/BudgetViewContext/hook';
 import BackToBudget from '@modules/garage/budget-view/actions/back-to-budget';
 import CompletedService from '@modules/garage/budget-view/actions/completed-budget';
@@ -19,7 +21,7 @@ const actionsByStatus: { [key in BudgetStatusEnum]?: React.ReactNode } = {
   [BudgetStatusEnum.ApprovedBudget]: <StartService />,
   [BudgetStatusEnum.BudgetRejected]: (
     <>
-      <Button icon="circle-off" variant="outline">
+      <Button icon={CircleOff} variant="outline">
         Cancelar orçamento
       </Button>
       <RemakeBudget />

--- a/src/modules/garage/budget-view/actions/remake-budget/index.tsx
+++ b/src/modules/garage/budget-view/actions/remake-budget/index.tsx
@@ -1,3 +1,4 @@
+import { CornerUpLeft } from 'lucide-react';
 import { useState } from 'react';
 
 import { useRemakeBudget } from '@core/service/budget';
@@ -32,7 +33,7 @@ export default function RemakeBudget() {
 
   return (
     <>
-      <Button icon="corner-up-left" color="primary" onClick={handleRemake}>
+      <Button icon={CornerUpLeft} color="primary" onClick={handleRemake}>
         Refazer Orçamento
       </Button>
 

--- a/src/modules/garage/budget-view/actions/send-for-approval/index.tsx
+++ b/src/modules/garage/budget-view/actions/send-for-approval/index.tsx
@@ -1,3 +1,4 @@
+import { Send } from 'lucide-react';
 import { useState } from 'react';
 
 import { useSendForApproveBudget } from '@core/service/budget';
@@ -36,7 +37,7 @@ export default function SendForApproval() {
 
   return (
     <>
-      <Button icon="send" onClick={handleSendForApproval}>
+      <Button icon={Send} onClick={handleSendForApproval}>
         Enviar para aprovação
       </Button>
 

--- a/src/modules/garage/budget-view/actions/send-whats-app/index.tsx
+++ b/src/modules/garage/budget-view/actions/send-whats-app/index.tsx
@@ -1,3 +1,5 @@
+import { MessageCircleMore } from 'lucide-react';
+
 import useBudgetViewContext from '@core/store/context/BudgetViewContext/hook';
 import useSendWhatApp from '@modules/garage/budget-view/hooks/useSendWhatsApp';
 import { Button } from '@shared/design-system/ui/button';
@@ -12,7 +14,7 @@ export default function SendWhatsApp() {
   };
 
   return (
-    <Button icon="message-circle-more" onClick={handleSendWhatsApp}>
+    <Button icon={MessageCircleMore} onClick={handleSendWhatsApp}>
       Enviar Whats App
     </Button>
   );

--- a/src/modules/garage/budget-view/actions/start-service/index.tsx
+++ b/src/modules/garage/budget-view/actions/start-service/index.tsx
@@ -1,3 +1,4 @@
+import { Wrench } from 'lucide-react';
 import { useState } from 'react';
 
 import { useStartServiceBudget } from '@core/service/budget';
@@ -28,7 +29,7 @@ export default function StartService() {
 
   return (
     <>
-      <Button icon="wrench" color="primary" onClick={handleSendForApproval}>
+      <Button icon={Wrench} color="primary" onClick={handleSendForApproval}>
         Iniciar Serviço
       </Button>
 

--- a/src/modules/garage/budget-view/add-budget-item-form/index.tsx
+++ b/src/modules/garage/budget-view/add-budget-item-form/index.tsx
@@ -1,4 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
+import { ListPlus } from 'lucide-react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import z from 'zod';
 
@@ -51,9 +52,9 @@ export function AddBugdetItemForm() {
       form={form}
       border
       title="Adicionar Item no Orçamento"
-      icon="list-plus"
+      icon={ListPlus}
       confirmButtonText="Adicionar"
-      confirmButtonProps={{ icon: 'list-plus' }}
+      confirmButtonProps={{ icon: ListPlus }}
       onValid={handleValid}
     >
       <FormField className="col-span-full" control={control} name="description" label="Descrição">

--- a/src/modules/garage/dashboard/index.tsx
+++ b/src/modules/garage/dashboard/index.tsx
@@ -1,3 +1,5 @@
+import { CircleDollarSign, Trello } from 'lucide-react';
+
 import { useGarageDashboard } from '@core/service/dashboard';
 import { DASHBOARD_CARD_TEST_ID } from '@modules/garage/dashboard/consts';
 import { DashboardGrid } from '@modules/garage/dashboard/dashboard-grid';
@@ -19,7 +21,7 @@ export default function Dashboard() {
   return (
     <Card data-testid={DASHBOARD_CARD_TEST_ID}>
       <CardHeader>
-        <CardTitle icon="trello">Dashboard</CardTitle>
+        <CardTitle icon={Trello}>Dashboard</CardTitle>
       </CardHeader>
 
       <CardContent>
@@ -29,7 +31,7 @@ export default function Dashboard() {
           loadingElement={<StatusCardSkeletons />}
           notFoundTitle="Nenhum orçamento em andamento."
           notFoundDescription={
-            <LinkButton to="/garage/orcamento" icon="circle-dollar-sign">
+            <LinkButton to="/garage/orcamento" icon={CircleDollarSign}>
               Adicionar orçamento
             </LinkButton>
           }

--- a/src/modules/garage/dashboard/status-card/index.tsx
+++ b/src/modules/garage/dashboard/status-card/index.tsx
@@ -1,3 +1,5 @@
+import { InfoIcon, NotebookPen } from 'lucide-react';
+
 import { DashboardItem } from '@core/models/dashboard';
 import DashboardButton from '@shared/components/dashboard-button';
 import StatusBadge from '@shared/components/status-badge';
@@ -30,11 +32,11 @@ const StatusCard = ({ onClick, item }: TStatusCardProps) => {
           <TooltipProvider delayDuration={200}>
             <Tooltip>
               <TooltipTrigger>
-                <Icon name="info" className="text-primary" />
+                <Icon className="text-primary" component={InfoIcon} />
               </TooltipTrigger>
               <TooltipContent className="max-w-80 text-left space-y-2" align="start">
                 <p className="flex justify-start items-center gap-2">
-                  <Icon className="inline" name="notebook-pen" />
+                  <Icon className="inline" component={NotebookPen} />
                   <b>Observações:</b>
                 </p>
                 <p>{observation}</p>

--- a/src/modules/garage/index.tsx
+++ b/src/modules/garage/index.tsx
@@ -1,3 +1,5 @@
+import { CircleDollarSign, FileSearch2, Search, Trello } from 'lucide-react';
+
 import BodyApp from '@layout/body-app';
 
 export default function GarageContent() {
@@ -7,22 +9,22 @@ export default function GarageContent() {
         {
           title: 'Dashboard',
           route: '/garage',
-          icon: 'trello',
+          icon: Trello,
         },
         {
           title: 'Adicionar Orçamento',
           route: '/garage/orcamento',
-          icon: 'circle-dollar-sign',
+          icon: CircleDollarSign,
         },
         {
           title: 'Orçamentos',
           route: '/garage/orcamentos',
-          icon: 'search',
+          icon: Search,
         },
         {
           title: 'Consultar Placa',
           route: '/garage/consulta-placa',
-          icon: 'file-search-2',
+          icon: FileSearch2,
         },
       ]}
     />

--- a/src/shared/components/budget-observation/index.tsx
+++ b/src/shared/components/budget-observation/index.tsx
@@ -1,3 +1,4 @@
+import { NotebookPen } from 'lucide-react';
 import { MouseEventHandler, useEffect, useRef, useState } from 'react';
 
 import { Button } from '@shared/design-system/ui/button';
@@ -52,7 +53,7 @@ export function BudgetObservation({
   return (
     <Card className="w-full">
       <CardHeader>
-        <CardTitle icon="notebook-pen" size="lg">
+        <CardTitle icon={NotebookPen} size="lg">
           <div className="flex gap-2">
             <div>{ofClient ? 'Obs. do Cliente' : 'Obs. da Oficina'}</div>
 

--- a/src/shared/components/budget-table/index.tsx
+++ b/src/shared/components/budget-table/index.tsx
@@ -1,3 +1,4 @@
+import { ListOrdered, Pencil, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 
 import type { TBudgetItem } from '@core/api/budget-item/types';
@@ -53,7 +54,7 @@ export default function BudgetTable({ allowActions = false }: TBudgetViewTablePr
 
   return (
     <>
-      <CardTitle icon="list-ordered" size="lg">
+      <CardTitle icon={ListOrdered} size="lg">
         Itens do Orçamento
       </CardTitle>
 
@@ -91,14 +92,14 @@ export default function BudgetTable({ allowActions = false }: TBudgetViewTablePr
                   <td className="flex justify-end space-x-2">
                     {/* // TODO criar modal para alterar */}
                     <Button
-                      icon="pencil"
+                      icon={Pencil}
                       size="sm"
                       variant="outline"
                       title="Alterar"
                       disabled={recordStatus === 'pending'}
                     />
                     <Button
-                      icon="trash-2"
+                      icon={Trash2}
                       size="sm"
                       variant="outline"
                       onClick={() => handleDeleteItemClick(item)}

--- a/src/shared/components/client-register-card/index.tsx
+++ b/src/shared/components/client-register-card/index.tsx
@@ -1,10 +1,12 @@
+import { UserPlus } from 'lucide-react';
+
 import { Alert, AlertDescription, AlertTitle } from '@shared/design-system/ui/alert';
 import LinkButton from '@shared/design-system/ui/link-button';
 
 export function ClientRegisterCard() {
   return (
     <Alert variant="primary">
-      <AlertTitle icon="user-plus">
+      <AlertTitle icon={UserPlus}>
         Você quer consultar a qualquer momento este e outros orçamentos do seu veículo?
       </AlertTitle>
       <AlertDescription className="space-y-4">

--- a/src/shared/components/loading-icon/index.tsx
+++ b/src/shared/components/loading-icon/index.tsx
@@ -1,14 +1,16 @@
+import { RefreshCw } from 'lucide-react';
+
 import { cn } from '@shared/design-system/helpers/utils';
 import Icon, { TIconProps } from '@shared/design-system/ui/icon';
 
-type TLoadingIconProps = Omit<TIconProps, 'name'>;
+type TLoadingIconProps = Omit<TIconProps, 'component'>;
 
 export default function LoadingIcon({ className, ...otherProps }: TLoadingIconProps) {
   return (
     <Icon
-      className={cn('inline text-primary animate-spin', className)}
-      name="rotate-cw"
       {...otherProps}
+      className={cn('inline text-primary animate-spin', className)}
+      component={RefreshCw}
     />
   );
 }

--- a/src/shared/design-system/ui/alert.tsx
+++ b/src/shared/design-system/ui/alert.tsx
@@ -35,7 +35,7 @@ type TAlertTitleProps = React.HTMLAttributes<HTMLHeadingElement> & {
 const AlertTitle = React.forwardRef<HTMLParagraphElement, TAlertTitleProps>(
   ({ className, icon, children, ...props }, ref) => (
     <div className="flex items-center gap-2">
-      {icon && <Icon name={icon} />}
+      {icon && <Icon component={icon} />}
       <h5 ref={ref} className={cn('font-medium leading-none tracking-tight', className)} {...props}>
         {children}
       </h5>

--- a/src/shared/design-system/ui/button.tsx
+++ b/src/shared/design-system/ui/button.tsx
@@ -76,11 +76,11 @@ export const Button = React.forwardRef<HTMLButtonElement, TButtonProps>(
       >
         {isLoading && <LoadingIcon size={size === 'icon' ? 'sm' : size} />}
 
-        {icon && !isLoading && <Icon name={icon} size={iconSize} {...iconProps} />}
+        {icon && !isLoading && <Icon component={icon} size={iconSize} {...iconProps} />}
 
         {children}
 
-        {secondIcon && <Icon name={secondIcon} size={iconSize} {...secondIconProps} />}
+        {secondIcon && <Icon component={secondIcon} size={iconSize} {...secondIconProps} />}
       </Comp>
     );
   },

--- a/src/shared/design-system/ui/card.tsx
+++ b/src/shared/design-system/ui/card.tsx
@@ -85,7 +85,7 @@ const CardTitle = React.forwardRef<
     data-testid={CARD_TITLE_TESTE_ID}
     className={cn(cardTitleVariants({ alignTitle, size }), className)}
   >
-    {icon && <Icon name={icon} size={size === 'lg' ? 'lg' : 'default'} />}
+    {icon && <Icon component={icon} size={size === 'lg' ? 'lg' : 'default'} />}
     <div ref={ref} className={cn(cardTitleTextVariants({ size }))} {...props}>
       {children}
     </div>

--- a/src/shared/design-system/ui/icon.tsx
+++ b/src/shared/design-system/ui/icon.tsx
@@ -1,6 +1,4 @@
-import { LucideProps } from 'lucide-react';
-import dynamicIconImports from 'lucide-react/dynamicIconImports';
-import { lazy, Suspense } from 'react';
+import { ElementType, Suspense } from 'react';
 
 type TSize = 'sm' | 'default' | 'lg';
 const sizeData: { [key in TSize]: number } = {
@@ -9,20 +7,23 @@ const sizeData: { [key in TSize]: number } = {
   lg: 34,
 };
 
-export type TIcons = keyof typeof dynamicIconImports;
-export type TIconProps = Omit<LucideProps, 'ref'> & {
-  name: TIcons;
+export type TIcons = ElementType;
+export type TIconProps = {
+  component: TIcons;
   size?: TSize;
+  className?: string;
 };
 
 const fallback = <div style={{ background: '#ddd', width: 24, height: 24 }} />;
 
-export default function Icon({ name, size = 'default', ...otherProps }: TIconProps) {
-  const LucideIcon = lazy(dynamicIconImports[name]);
-
+export default function Icon({
+  component: Component,
+  size = 'default',
+  ...otherProps
+}: TIconProps) {
   return (
     <Suspense fallback={fallback}>
-      <LucideIcon {...otherProps} width={sizeData[size]} />
+      <Component {...otherProps} width={sizeData[size]} />
     </Suspense>
   );
 }

--- a/src/shared/design-system/ui/link-button/index.tsx
+++ b/src/shared/design-system/ui/link-button/index.tsx
@@ -25,7 +25,9 @@ const LinkButton: FunctionComponent<TLinkButtonProps> = ({
 }) => {
   return (
     <Link className={cn(buttonVariants({ variant, size }), className)} {...otherProps}>
-      {icon && <Icon name={icon as TIcons} size={size === 'icon' ? 'sm' : size} {...iconProps} />}
+      {icon && (
+        <Icon component={icon as TIcons} size={size === 'icon' ? 'sm' : size} {...iconProps} />
+      )}
       {children}
     </Link>
   );

--- a/src/shared/design-system/ui/modal/index.tsx
+++ b/src/shared/design-system/ui/modal/index.tsx
@@ -1,3 +1,4 @@
+import { CircleX } from 'lucide-react';
 import type { PropsWithChildren, ReactNode } from 'react';
 
 import { Button, TButtonProps } from '@shared/design-system/ui/button';
@@ -40,7 +41,7 @@ const Modal = ({
         <div>
           {onClose && (
             <div className="text-right">
-              <Button icon="circle-x" variant="ghost" size="icon" onClick={onClose} />
+              <Button icon={CircleX} variant="ghost" size="icon" onClick={onClose} />
             </div>
           )}
           <CardTitle icon={icon}>{title}</CardTitle>


### PR DESCRIPTION
Remoção do import `lucide-react/dynamicIconImports`, pois ele faz com que seja enviado todos os ícones da lib para o build.